### PR TITLE
Confirm password for admin user in seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-User.create!(username: "admin", password: "admin")
+User.create!(username: "admin", password: "admin", password_confirmation: "admin")
 
 Rule.create!(key: :points_for_win, value: 2, ordinal: 0)
 Rule.create!(key: :points_for_time_win, value: 1, ordinal: 1)


### PR DESCRIPTION
The seed script to create the default `admin` user
required the `password_confirmation` field in order
to run successfully.

I have added the required field: executing `heroku run rake db:seed`
runs successfully now and I can log-in as the `admin` user.