### PR TITLE
Allow points to be awarded for participation

### DIFF
--- a/app/helpers/leaderboard_helper.rb
+++ b/app/helpers/leaderboard_helper.rb
@@ -1,0 +1,9 @@
+module LeaderboardHelper
+  def participation_points_active?
+    Rule.value_for("points_for_participation", 0) > 0
+  end
+
+  def achievement_points_active?
+    Achievement.count > 0
+  end
+end

--- a/app/models/leaderboard_row.rb
+++ b/app/models/leaderboard_row.rb
@@ -3,8 +3,10 @@ class LeaderboardRow
 
   attr_accessor :position
   attr_reader :player, :points, :played, :corp_wins, :runner_wins
+  attr_reader :participation_points, :achievement_points
 
   delegate :points_for_result, to: :@ruleset
+  delegate :points_for_participation, to: :@ruleset
 
   def initialize(player, ruleset)
     @position = 0
@@ -13,6 +15,8 @@ class LeaderboardRow
     @played = 0
     @corp_wins = 0
     @runner_wins = 0
+    @participation_points = 0
+    @achievement_points = 0
 
     @ruleset = ruleset
   end
@@ -22,7 +26,14 @@ class LeaderboardRow
     @corp_wins += 1 if corp?(game) && result(game) == :win
     @runner_wins += 1 if runner?(game) && result(game) == :win
     @points += points_for_result(result(game))
-    @points += game.points_for_achievements(@player)
+    game.points_for_achievements(@player).tap do |ap|
+      @points += ap
+      @achievement_points += ap
+    end
+    points_for_participation(@participation_points).tap do |pp|
+      @points += pp
+      @participation_points += pp
+    end
   end
 
   def <=>(other)

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -8,11 +8,13 @@ class Rule < ActiveRecord::Base
     points_for_win:       0,
     points_for_loss:      1,
     points_for_tie:       2,
-    points_for_time_win:  3
+    points_for_time_win:  3,
+    points_for_participation:     4,
+    max_points_for_participation: 5
   }
 
-  def self.value_for(key)
-    rule_for(key).value
+  def self.value_for(key, default = nil)
+    rule_for(key).value || default
   end
 
   def self.rule_for(key)
@@ -20,6 +22,6 @@ class Rule < ActiveRecord::Base
   end
 
   def update_ordinal
-    ordinal = KEYS[key.to_sym]
+    self.ordinal = KEYS[key.to_sym]
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -4,14 +4,14 @@ class Rule < ActiveRecord::Base
 
   validates_uniqueness_of :key
 
-  KEYS = {
-    points_for_win:       0,
-    points_for_loss:      1,
-    points_for_tie:       2,
-    points_for_time_win:  3,
-    points_for_participation:     4,
-    max_points_for_participation: 5
-  }
+  KEYS = [
+    :points_for_win,
+    :points_for_loss,
+    :points_for_tie,
+    :points_for_time_win,
+    :points_for_participation,
+    :max_points_for_participation
+  ]
 
   def self.value_for(key, default = nil)
     rule_for(key).value || default
@@ -22,6 +22,6 @@ class Rule < ActiveRecord::Base
   end
 
   def update_ordinal
-    self.ordinal = KEYS[key.to_sym]
+    self.ordinal = KEYS.index(key.to_sym)
   end
 end

--- a/app/models/ruleset.rb
+++ b/app/models/ruleset.rb
@@ -8,7 +8,15 @@ class Ruleset
   end
 
   def points_for_result(result)
-    Rule.value_for("points_for_#{result}") || 0
+    Rule.value_for("points_for_#{result}", 0)
+  end
+
+  def points_for_participation(current)
+    max = Rule.value_for("max_points_for_participation", 100)
+    Rule.value_for("points_for_participation", 0).tap do |points|
+      return 0 if current >= max
+      return (max - current) if (current + points) >= max
+    end
   end
 
   private

--- a/app/views/leaderboard/_table.html.haml
+++ b/app/views/leaderboard/_table.html.haml
@@ -4,6 +4,8 @@
     %th Name
     %th Played
     %th Wins (Corp/Runner)
+    %th= "Participation Points" if participation_points_active?
+    %th= "Achievement Points" if achievement_points_active?
     %th Points
   - rows.each do |row|
     %tr
@@ -11,4 +13,6 @@
       %td= link_to row.player.name, player_path(row.player)
       %td= row.played
       %td= "#{row.corp_wins}/#{row.runner_wins}"
+      %td= row.participation_points if participation_points_active?
+      %td= row.achievement_points if achievement_points_active?
       %td= row.points

--- a/app/views/league/edit.html.haml
+++ b/app/views/league/edit.html.haml
@@ -15,7 +15,7 @@
         = f.text_area :home_content, class: "form-control", rows: 5
     - @rules.each do |rule|
       .form-group
-        = label_tag rule.key, rule.key.to_s.titleize, class: ["col-sm-2", "control-label"]
+        = label_tag rule.key, t(rule.key), class: ["col-sm-2", "control-label"]
         .col-sm-10
           = text_field_tag "rules[#{rule.key}]", rule.value, class: "form-control"
     .form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,3 +97,9 @@ en:
   update_password_failed: "Update password failed"
 
   rules: "Rules"
+  points_for_win: "Points awarded for a Win"
+  points_for_loss: "Points awarded for a Loss"
+  points_for_tie: "Points awarded for a Tie"
+  points_for_time_win: "Points awarded for a Time Win"
+  points_for_participation: "Participation points per game"
+  max_points_for_participation: "Max. participation points in a season"

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Leaderboard, type: :model do
   context "row" do
     before do
       create(:rule, key: :points_for_win, value: 2)
+      create(:rule, key: :points_for_participation, value: 2)
     end
 
     let(:row) { leaderboard.rows[common_player.id] }
@@ -18,8 +19,9 @@ RSpec.describe Leaderboard, type: :model do
     describe("#played") { it { expect(row.played).to be(2) } }
     describe("#corp_wins") { it { expect(row.corp_wins).to be(1) } }
     describe("#runner_wins") { it { expect(row.runner_wins).to be(1) } }
-    describe("#points") { it { expect(row.points).to be(4) } }
+    describe("#points") { it { expect(row.points).to be(8) } }
     describe("#weak_side_wins") { it { expect(row.weak_side_wins).to be(1) } }
+    describe("#participation_points") { it { expect(row.participation_points).to be(4) } }
 
     context "with achievement" do
       let(:achievement) { create(:achievement, side: :corp, points: 3) }
@@ -32,7 +34,8 @@ RSpec.describe Leaderboard, type: :model do
         )
       end
 
-      describe("#points") { it { expect(row.points).to eq(7) } }
+      describe("#points") { it { expect(row.points).to eq(11) } }
+      describe("#achievement_points") { it { expect(row.achievement_points).to eq(3) } }
     end
   end
 

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Leaderboard, type: :model do
     describe("#runner_wins") { it { expect(row.runner_wins).to be(1) } }
     describe("#points") { it { expect(row.points).to be(8) } }
     describe("#weak_side_wins") { it { expect(row.weak_side_wins).to be(1) } }
-    describe("#participation_points") { it { expect(row.participation_points).to be(4) } }
+    describe("#participation_points") do
+      it { expect(row.participation_points).to be(4) }
+    end
 
     context "with achievement" do
       let(:achievement) { create(:achievement, side: :corp, points: 3) }
@@ -35,7 +37,9 @@ RSpec.describe Leaderboard, type: :model do
       end
 
       describe("#points") { it { expect(row.points).to eq(11) } }
-      describe("#achievement_points") { it { expect(row.achievement_points).to eq(3) } }
+      describe("#achievement_points") do
+        it { expect(row.achievement_points).to eq(3) }
+      end
     end
   end
 

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe Rule, type: :model do
       it { expect(duplicate).not_to be_valid }
     end
   end
+
+  it "should fall back to default" do
+    expect(Rule.value_for("doesn't exist", 99)).to eq(99)
+  end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe Rule, type: :model do
   it "should fall back to default" do
     expect(Rule.value_for("doesn't exist", 99)).to eq(99)
   end
+
+  it "should auto-assign correct ordinal" do
+    rule = create(:rule, key: :points_for_time_win)
+
+    expect(rule.ordinal).to eq(3)
+  end
 end

--- a/spec/models/ruleset_spec.rb
+++ b/spec/models/ruleset_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Ruleset, type: :model do
+  let(:ruleset) { Ruleset.new }
+  before do
+    create(:rule, key: "points_for_participation", value: 3)
+    create(:rule, key: "max_points_for_participation", value: 5)
+  end
+
+  describe "#points_for_participation" do
+    context "full amount" do
+      it do
+        expect(ruleset.points_for_participation(0)).to eq(3)
+      end
+    end
+
+    context "partial" do
+      it do
+        expect(ruleset.points_for_participation(3)).to eq(2)
+      end
+    end
+
+    context "none" do
+      it do
+        expect(ruleset.points_for_participation(5)).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Points are awarded as defined in league settings for each game played
Participation points can be capped in total

Also refactored some rule and ruleset methods
Added participation and achievement points to leaderboard