### PR TITLE
Allow user to customise league tiebreakers from specified list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem "bcrypt", "~> 3.1.7"
 gem "haml-rails", "~> 0.9"
 gem "bootstrap-sass"
 gem "redcarpet"
+gem "ranked-model"
+gem "jquery-ui-rails"
 
 group :development, :test do
   gem "web-console", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     json (1.8.3)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
@@ -138,6 +140,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.4.2)
+    ranked-model (0.4.0)
+      activerecord (>= 3.1.12)
     redcarpet (3.3.2)
     rspec-core (3.3.0)
       rspec-support (~> 3.3.0)
@@ -209,9 +213,11 @@ DEPENDENCIES
   factory_girl_rails
   haml-rails (~> 0.9)
   jquery-rails
+  jquery-ui-rails
   pg
   pry-rails
   rails (= 4.2.1)
+  ranked-model
   redcarpet
   rspec-rails
   rubocop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,6 @@
 //= require jquery
 //= require bootstrap-sprockets
 //= require jquery_ujs
+//= require jquery-ui/sortable
+//= require jquery-ui/effect-highlight
 //= require_tree .

--- a/app/assets/javascripts/tiebreakers.coffee
+++ b/app/assets/javascripts/tiebreakers.coffee
@@ -1,28 +1,15 @@
-jQuery ->
-  if $('#sortable').length > 0
-    table_width = $('#sortable').width()
-    cells = $('.table').find('tr')[0].cells.length
-    desired_width = table_width / cells + 'px'
-    $('.table td').css('width', desired_width)
-
-    $('#sortable').sortable(
-      axis: 'y'
-      items: '.item'
-      cursor: 'move'
-
-      sort: (e, ui) ->
-        ui.item.addClass('active-item-shadow')
-      stop: (e, ui) ->
-        ui.item.removeClass('active-item-shadow')
-        # highlight the row on drop to indicate an update
-        ui.item.children('td').effect('highlight', {}, 1000)
-      update: (e, ui) ->
-        item_id = ui.item.data('item-id')
-        position = ui.item.index() # this will not work with paginated items, as the index is zero on every page
-        $.ajax(
-          type: 'PATCH'
-          url: "/tiebreakers/#{item_id}"
-          dataType: 'json'
-          data: { tiebreaker: { ordinal_position: position } }
-        )
-    )
+$ ->
+  $("#sortable-tiebreakers").sortable(
+    axis: "y"
+    items: ".item"
+    cursor: "move"
+    stop: (e, ui) ->
+      ui.item.children("td").effect("highlight", {}, 1000)
+    update: (e, ui) ->
+      $.ajax(
+        type: "PATCH"
+        url: "/tiebreakers/#{ui.item.data("item-id")}"
+        dataType: "json"
+        data: { tiebreaker: { ordinal_position: ui.item.index() } }
+      )
+  )

--- a/app/assets/javascripts/tiebreakers.coffee
+++ b/app/assets/javascripts/tiebreakers.coffee
@@ -1,0 +1,28 @@
+jQuery ->
+  if $('#sortable').length > 0
+    table_width = $('#sortable').width()
+    cells = $('.table').find('tr')[0].cells.length
+    desired_width = table_width / cells + 'px'
+    $('.table td').css('width', desired_width)
+
+    $('#sortable').sortable(
+      axis: 'y'
+      items: '.item'
+      cursor: 'move'
+
+      sort: (e, ui) ->
+        ui.item.addClass('active-item-shadow')
+      stop: (e, ui) ->
+        ui.item.removeClass('active-item-shadow')
+        # highlight the row on drop to indicate an update
+        ui.item.children('td').effect('highlight', {}, 1000)
+      update: (e, ui) ->
+        item_id = ui.item.data('item-id')
+        position = ui.item.index() # this will not work with paginated items, as the index is zero on every page
+        $.ajax(
+          type: 'PATCH'
+          url: "/tiebreakers/#{item_id}"
+          dataType: 'json'
+          data: { tiebreaker: { ordinal_position: position } }
+        )
+    )

--- a/app/controllers/league_controller.rb
+++ b/app/controllers/league_controller.rb
@@ -25,6 +25,15 @@ class LeagueController < ApplicationController
   end
 
   def tiebreakers
+    @tiebreakers = Tiebreaker.ordered
+  end
+
+  def update_tiebreaker
+    @tiebreaker = Tiebreaker.find(tiebreaker_params[:tiebreaker_id])
+    @tiebreaker.ordinal_position = tiebreaker_params[:ordinal_position]
+    @tiebreaker.save
+
+    render nothing: true
   end
 
   private
@@ -35,5 +44,9 @@ class LeagueController < ApplicationController
 
   def rules_params
     params[:rules] || {}
+  end
+
+  def tiebreaker_params
+    params.require(:tiebreaker).permit(:tiebreaker_id, :ordinal_position)
   end
 end

--- a/app/controllers/league_controller.rb
+++ b/app/controllers/league_controller.rb
@@ -24,18 +24,6 @@ class LeagueController < ApplicationController
     redirect_to edit_rules_path, notice: t(:updated_rules)
   end
 
-  def tiebreakers
-    @tiebreakers = Tiebreaker.ordered
-  end
-
-  def update_tiebreaker
-    @tiebreaker = Tiebreaker.find(tiebreaker_params[:tiebreaker_id])
-    @tiebreaker.ordinal_position = tiebreaker_params[:ordinal_position]
-    @tiebreaker.save
-
-    render nothing: true
-  end
-
   private
 
   def league_params
@@ -44,9 +32,5 @@ class LeagueController < ApplicationController
 
   def rules_params
     params[:rules] || {}
-  end
-
-  def tiebreaker_params
-    params.require(:tiebreaker).permit(:tiebreaker_id, :ordinal_position)
   end
 end

--- a/app/controllers/league_controller.rb
+++ b/app/controllers/league_controller.rb
@@ -2,20 +2,29 @@ class LeagueController < ApplicationController
   before_action :authorise
 
   def edit
-    @rules = @league.all_rules
   end
 
   def update
     if @league.update_attributes(league_params)
-      rules_params.each do |key, value|
-        Rule.rule_for(key).update(value: value)
-      end
       redirect_to edit_league_path, notice: t(:updated_league)
     else
       flash.now.alert = t(:update_league_failed)
-      @rules = @league.all_rules
       render :edit
     end
+  end
+
+  def rules
+    @rules = @league.all_rules
+  end
+
+  def update_rules
+    rules_params.each do |key, value|
+      Rule.rule_for(key).update(value: value)
+    end
+    redirect_to edit_rules_path, notice: t(:updated_rules)
+  end
+
+  def tiebreakers
   end
 
   private

--- a/app/controllers/tiebreakers_controller.rb
+++ b/app/controllers/tiebreakers_controller.rb
@@ -1,0 +1,42 @@
+class TiebreakersController < ApplicationController
+  before_action :authorise
+
+  def index
+    @tiebreakers = Tiebreaker.ordered
+  end
+
+  def create
+    if Tiebreaker.new(create_params).save
+      redirect_to tiebreakers_path, notice: t(:added_tiebreaker)
+    else
+      flash.now.alert = t(:add_tiebreaker_failed)
+      @tiebreakers = Tiebreaker.ordered
+      render :index
+    end
+  end
+
+  def update
+    @tiebreaker = Tiebreaker.find(params[:id])
+    @tiebreaker.ordinal_position = update_params[:ordinal_position]
+    @tiebreaker.save
+
+    render nothing: true
+  end
+
+  def destroy
+    @tiebreaker = Tiebreaker.find(params[:id])
+    @tiebreaker.destroy
+
+    redirect_to tiebreakers_path, notice: t(:removed_tiebreaker)
+  end
+
+  private
+
+  def create_params
+    params.require(:tiebreaker).permit(:tiebreaker)
+  end
+
+  def update_params
+    params.require(:tiebreaker).permit(:ordinal_position)
+  end
+end

--- a/app/helpers/league_helper.rb
+++ b/app/helpers/league_helper.rb
@@ -1,0 +1,5 @@
+module LeagueHelper
+  def tab_class(active, current)
+    :active if current == active
+  end
+end

--- a/app/helpers/tiebreaker_helper.rb
+++ b/app/helpers/tiebreaker_helper.rb
@@ -1,0 +1,5 @@
+module TiebreakerHelper
+  def tiebreaker_options
+    Tiebreaker.available_tiebreakers.keys.map { |tb| [t(tb), tb] }
+  end
+end

--- a/app/models/ruleset.rb
+++ b/app/models/ruleset.rb
@@ -19,9 +19,7 @@ class Ruleset
     end
   end
 
-  private
-
   def rankers
-    [Ranker::MostPoints, Ranker::MostWeakSideWins, Ranker::FewestPlayed]
+    Tiebreaker.all.map { |t| "Ranker::#{t.tiebreaker.camelize}".constantize }
   end
 end

--- a/app/models/ruleset.rb
+++ b/app/models/ruleset.rb
@@ -20,6 +20,6 @@ class Ruleset
   end
 
   def rankers
-    Tiebreaker.all.map { |t| "Ranker::#{t.tiebreaker.camelize}".constantize }
+    Tiebreaker.ordered.map { |t| "Ranker::#{t.tiebreaker.camelize}".constantize }
   end
 end

--- a/app/models/ruleset.rb
+++ b/app/models/ruleset.rb
@@ -20,6 +20,8 @@ class Ruleset
   end
 
   def rankers
-    Tiebreaker.ordered.map { |t| "Ranker::#{t.tiebreaker.camelize}".constantize }
+    Tiebreaker.ordered.map do |t|
+      "Ranker::#{t.tiebreaker.camelize}".constantize
+    end
   end
 end

--- a/app/models/tiebreaker.rb
+++ b/app/models/tiebreaker.rb
@@ -1,6 +1,6 @@
 class Tiebreaker < ActiveRecord::Base
   enum tiebreaker: [:most_points, :most_weak_side_wins, :fewest_played]
-  validates_uniqueness_of :tiebreaker
+  validates :tiebreaker, uniqueness: true
 
   include RankedModel
   ranks :ordinal
@@ -8,6 +8,6 @@ class Tiebreaker < ActiveRecord::Base
 
   def self.available_tiebreakers
     taken = pluck(:tiebreaker)
-    tiebreakers.reject { |k, v| taken.include?(v) }
+    tiebreakers.reject { |_, v| taken.include?(v) }
   end
 end

--- a/app/models/tiebreaker.rb
+++ b/app/models/tiebreaker.rb
@@ -1,0 +1,6 @@
+class Tiebreaker < ActiveRecord::Base
+  enum tiebreaker: [:most_points, :most_weak_side_wins, :fewest_played]
+  validates_uniqueness_of :tiebreaker
+
+  scope :ordered, -> { order(ordinal: :asc) }
+end

--- a/app/models/tiebreaker.rb
+++ b/app/models/tiebreaker.rb
@@ -2,5 +2,12 @@ class Tiebreaker < ActiveRecord::Base
   enum tiebreaker: [:most_points, :most_weak_side_wins, :fewest_played]
   validates_uniqueness_of :tiebreaker
 
-  scope :ordered, -> { order(ordinal: :asc) }
+  include RankedModel
+  ranks :ordinal
+  scope :ordered, -> { rank(:ordinal) }
+
+  def self.available_tiebreakers
+    taken = pluck(:tiebreaker)
+    tiebreakers.reject { |k, v| taken.include?(v) }
+  end
 end

--- a/app/views/league/_navigation.html.haml
+++ b/app/views/league/_navigation.html.haml
@@ -4,4 +4,4 @@
   %li{role: :presentation, class: tab_class(active, :rules)}
     =link_to t(:edit_rules), edit_rules_path
   %li{role: :presentation, class: tab_class(active, :tiebreakers)}
-    =link_to t(:edit_tiebreakers), edit_tiebreakers_path
+    =link_to t(:edit_tiebreakers), tiebreakers_path

--- a/app/views/league/_navigation.html.haml
+++ b/app/views/league/_navigation.html.haml
@@ -1,0 +1,7 @@
+%ul.nav.nav-tabs
+  %li{role: :presentation, class: tab_class(active, :league)}
+    =link_to t(:edit_league), edit_league_path
+  %li{role: :presentation, class: tab_class(active, :rules)}
+    =link_to t(:edit_rules), edit_rules_path
+  %li{role: :presentation, class: tab_class(active, :tiebreakers)}
+    =link_to t(:edit_tiebreakers), edit_tiebreakers_path

--- a/app/views/league/edit.html.haml
+++ b/app/views/league/edit.html.haml
@@ -1,28 +1,23 @@
+= render "navigation", active: :league
 %h2= t(:edit_league)
-.row
-  = form_for @league, url: update_league_path, html: { class: "form-horizontal" } do |f|
-    .form-group
-      = f.label :name, t(:league_name), class: ["col-sm-2", "control-label"]
-      .col-sm-10
-        = f.text_field :name, class: "form-control"
-    .form-group
-      = f.label :rules_content, t(:league_rules), class: ["col-sm-2", "control-label"]
-      .col-sm-10
-        = f.text_area :rules_content, class: "form-control", rows: 5
-    .form-group
-      = f.label :home_content, t(:homepage_content), class: ["col-sm-2", "control-label"]
-      .col-sm-10
-        = f.text_area :home_content, class: "form-control", rows: 5
-    - @rules.each do |rule|
-      .form-group
-        = label_tag rule.key, t(rule.key), class: ["col-sm-2", "control-label"]
-        .col-sm-10
-          = text_field_tag "rules[#{rule.key}]", rule.value, class: "form-control"
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        = button_tag class: ["btn", "btn-success"] do
-          %span.glyphicon.glyphicon-pencil
-          = t(:save_league)
-        %a.btn.btn-danger{ href: root_path }
-          %span.glyphicon.glyphicon-remove
-          = t(:cancel)
+= form_for @league, url: update_league_path, html: { class: "form-horizontal" } do |f|
+  .form-group
+    = f.label :name, t(:league_name), class: ["col-sm-2", "control-label"]
+    .col-sm-10
+      = f.text_field :name, class: "form-control"
+  .form-group
+    = f.label :rules_content, t(:league_rules), class: ["col-sm-2", "control-label"]
+    .col-sm-10
+      = f.text_area :rules_content, class: "form-control", rows: 5
+  .form-group
+    = f.label :home_content, t(:homepage_content), class: ["col-sm-2", "control-label"]
+    .col-sm-10
+      = f.text_area :home_content, class: "form-control", rows: 5
+  .form-group
+    .col-sm-offset-2.col-sm-10
+      = button_tag class: ["btn", "btn-success"] do
+        %span.glyphicon.glyphicon-pencil
+        = t(:save_league)
+      %a.btn.btn-danger{ href: root_path }
+        %span.glyphicon.glyphicon-remove
+        = t(:cancel)

--- a/app/views/league/rules.html.haml
+++ b/app/views/league/rules.html.haml
@@ -1,0 +1,16 @@
+= render "navigation", active: :rules
+%h2= t(:edit_rules)
+= form_for @league, url: update_rules_path, html: { class: "form-horizontal" } do |f|
+  - @rules.each do |rule|
+    .form-group
+      = label_tag rule.key, t(rule.key), class: ["col-sm-2", "control-label"]
+      .col-sm-10
+        = text_field_tag "rules[#{rule.key}]", rule.value, class: "form-control"
+  .form-group
+    .col-sm-offset-2.col-sm-10
+      = button_tag class: ["btn", "btn-success"] do
+        %span.glyphicon.glyphicon-pencil
+        = t(:save_league)
+      %a.btn.btn-danger{ href: root_path }
+        %span.glyphicon.glyphicon-remove
+        = t(:cancel)

--- a/app/views/league/tiebreakers.html.haml
+++ b/app/views/league/tiebreakers.html.haml
@@ -1,0 +1,2 @@
+= render "navigation", active: :tiebreakers
+%h2= t(:edit_tiebreakers)

--- a/app/views/league/tiebreakers.html.haml
+++ b/app/views/league/tiebreakers.html.haml
@@ -1,2 +1,0 @@
-= render "navigation", active: :tiebreakers
-%h2= t(:edit_tiebreakers)

--- a/app/views/tiebreakers/index.html.haml
+++ b/app/views/tiebreakers/index.html.haml
@@ -5,7 +5,11 @@
     %table.table.table-bordered.table-striped#sortable
       - @tiebreakers.each do |tiebreaker|
         %tr{ data: { "item-id" => tiebreaker.id }, class: :item}
-          %td= tiebreaker.tiebreaker
+          %td
+            = t(tiebreaker.tiebreaker)
+          %td
+            = link_to tiebreaker_path(tiebreaker), method: :delete do
+              %span.glyphicon.glyphicon-trash
   .col-sm-6
     = form_for :tiebreaker, url: tiebreakers_path do |f|
       .form-group

--- a/app/views/tiebreakers/index.html.haml
+++ b/app/views/tiebreakers/index.html.haml
@@ -2,7 +2,7 @@
 %h2= t(:edit_tiebreakers)
 .row
   .col-sm-6
-    %table.table.table-bordered.table-striped#sortable
+    %table.table.table-bordered.table-striped#sortable-tiebreakers
       - @tiebreakers.each do |tiebreaker|
         %tr{ data: { "item-id" => tiebreaker.id }, class: :item}
           %td

--- a/app/views/tiebreakers/index.html.haml
+++ b/app/views/tiebreakers/index.html.haml
@@ -1,0 +1,19 @@
+= render "league/navigation", active: :tiebreakers
+%h2= t(:edit_tiebreakers)
+.row
+  .col-sm-6
+    %table.table.table-bordered.table-striped#sortable
+      - @tiebreakers.each do |tiebreaker|
+        %tr{ data: { "item-id" => tiebreaker.id }, class: :item}
+          %td= tiebreaker.tiebreaker
+  .col-sm-6
+    = form_for :tiebreaker, url: tiebreakers_path do |f|
+      .form-group
+        = f.label :tiebreaker, t(:tiebreaker), class: ["col-sm-2", "control-label"]
+        .col-sm-10
+          = f.select :tiebreaker, tiebreaker_options, {}, class: "form-control"
+      .form-group
+        .col-sm-offset-2.col-sm-10
+          = button_tag class: ["btn", "btn-success"] do
+            %span.glyphicon.glyphicon-pencil
+            = t(:add_tiebreaker)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,12 +82,15 @@ en:
   point: "point"
 
   league_name: "Name"
-  edit_league: "Edit league"
+  edit_league: "Edit League"
   save_league: "Save"
   updated_league: "Updated league"
   update_league_failed: "Couldn't update league"
   league_rules: "Rules page content (format in markdown)"
   homepage_content: "Homepage message (format in markdown)"
+  edit_rules: "Edit Rules"
+  updated_rules: "Updated rules"
+  edit_tiebreakers: "Edit Tiebreakers"
 
   change_password: "Change password"
   password: "Password"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,6 @@ en:
   homepage_content: "Homepage message (format in markdown)"
   edit_rules: "Edit Rules"
   updated_rules: "Updated rules"
-  edit_tiebreakers: "Edit Tiebreakers"
 
   change_password: "Change password"
   password: "Password"
@@ -113,3 +112,10 @@ en:
   participation_points: "Participation points"
   achievement_points: "Achievement points"
   leaderboard_points: "Points"
+
+  edit_tiebreakers: "Edit Tiebreakers"
+  added_tiebreaker: "Added tiebreaker"
+  removed_tiebreaker: "Removed tiebreaker"
+  most_points: "Most points"
+  most_weak_side_wins: "Most weak-side wins"
+  fewest_played: "Fewest games played"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
   resources :games, except: :show
   resources :players, except: :new
+  resources :tiebreakers, except: [:show, :new, :edit]
   root "leaderboard#show"
   get "jack-in" => "sessions#new", as: :login
   post "jack-in" => "sessions#create", as: :do_login
@@ -14,7 +15,6 @@ Rails.application.routes.draw do
   patch "manage_league" => "league#update", as: :update_league
   get "manage_rules" => "league#rules", as: :edit_rules
   patch "manage_rules" => "league#update_rules", as: :update_rules
-  get "manage_tiebreakers" => "league#tiebreakers", as: :edit_tiebreakers
   get "change_password" => "users#edit", as: :change_password
   patch "change_password" => "users#update", as: :update_password
   get "rules" => "rules#show", as: :rules

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   get "jack-out" => "sessions#destroy", as: :logout
   get "manage_league" => "league#edit", as: :edit_league
   patch "manage_league" => "league#update", as: :update_league
+  get "manage_rules" => "league#rules", as: :edit_rules
+  patch "manage_rules" => "league#update_rules", as: :update_rules
+  get "manage_tiebreakers" => "league#tiebreakers", as: :edit_tiebreakers
   get "change_password" => "users#edit", as: :change_password
   patch "change_password" => "users#update", as: :update_password
   get "rules" => "rules#show", as: :rules

--- a/db/migrate/20150823202811_create_tiebreakers.rb
+++ b/db/migrate/20150823202811_create_tiebreakers.rb
@@ -1,0 +1,8 @@
+class CreateTiebreakers < ActiveRecord::Migration
+  def change
+    create_table :tiebreakers do |t|
+      t.integer :tiebreaker
+      t.integer :ordinal
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150819204014) do
+ActiveRecord::Schema.define(version: 20150823202811) do
 
   create_table "achievements", force: :cascade do |t|
     t.string   "title"
@@ -63,6 +63,11 @@ ActiveRecord::Schema.define(version: 20150819204014) do
   end
 
   add_index "rules", ["league_id"], name: "index_rules_on_league_id"
+
+  create_table "tiebreakers", force: :cascade do |t|
+    t.integer "tiebreaker"
+    t.integer "ordinal"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "username"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,3 +4,5 @@ Rule.create!(key: :points_for_win, value: 2, ordinal: 0)
 Rule.create!(key: :points_for_time_win, value: 1, ordinal: 1)
 Rule.create!(key: :points_for_tie, value: 1, ordinal: 2)
 Rule.create!(key: :points_for_loss, value: 0, ordinal: 3)
+
+Tiebreaker.create!(tiebreaker: :most_points, ordinal: 0)

--- a/spec/controllers/league_controller_spec.rb
+++ b/spec/controllers/league_controller_spec.rb
@@ -42,13 +42,47 @@ RSpec.describe LeagueController, type: :controller do
           home_content: "Home content"
         }
       end
+    end
+
+    describe "GET rules" do
+      before do
+        get :rules
+      end
+
+      it "is successful" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:rules)
+      end
+
+      it "assigns rules" do
+        expect(assigns(:rules)).to eq(League.current.all_rules)
+      end
+    end
+
+    describe "POST update_rules" do
+      it "is successful" do
+        post :update_rules
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:notice]).to eq(I18n.t(:updated_rules))
+      end
 
       it "updates rules" do
-        post :update,
-          league: { name: "" },
+        post :update_rules,
           rules: { "points_for_tie" => "99" }
 
         expect(Rule.rule_for(:points_for_tie).value).to eq(99)
+      end
+    end
+
+    describe "GET tiebreakers" do
+      before do
+        get :tiebreakers
+      end
+
+      it "is successful" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:tiebreakers)
       end
     end
   end
@@ -63,6 +97,24 @@ RSpec.describe LeagueController, type: :controller do
     describe "POST update" do
       it_behaves_like "a restricted controller" do
         let(:go) { post :update, league: { name: "Test" } }
+      end
+    end
+
+    describe "GET rules" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { get :rules }
+      end
+    end
+
+    describe "POST update_rules" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { post :update_rules }
+      end
+    end
+
+    describe "GET tiebreakers" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { get :tiebreakers }
       end
     end
   end

--- a/spec/controllers/league_controller_spec.rb
+++ b/spec/controllers/league_controller_spec.rb
@@ -74,17 +74,6 @@ RSpec.describe LeagueController, type: :controller do
         expect(Rule.rule_for(:points_for_tie).value).to eq(99)
       end
     end
-
-    describe "GET tiebreakers" do
-      before do
-        get :tiebreakers
-      end
-
-      it "is successful" do
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:tiebreakers)
-      end
-    end
   end
 
   context "not authorised" do
@@ -109,12 +98,6 @@ RSpec.describe LeagueController, type: :controller do
     describe "POST update_rules" do
       it_behaves_like "a restricted controller" do
         let(:go) { post :update_rules }
-      end
-    end
-
-    describe "GET tiebreakers" do
-      it_behaves_like "a restricted controller" do
-        let(:go) { get :tiebreakers }
       end
     end
   end

--- a/spec/controllers/tiebreakers_controller_spec.rb
+++ b/spec/controllers/tiebreakers_controller_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe TiebreakersController, type: :controller do
+  context "authorised" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:authorise)
+        .and_return(nil)
+    end
+
+    describe "GET index" do
+      before do
+        create(:tiebreaker, tiebreaker: :most_points)
+        get :index
+      end
+
+      it "is successful" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:index)
+      end
+
+      it "assigns tiebreakers correctly" do
+        expect(assigns(:tiebreakers)).to be_a(ActiveRecord::Relation)
+        assigns(:tiebreakers).each do |row|
+          expect(row).to be_a(Tiebreaker)
+        end
+      end
+    end
+
+    describe "POST create" do
+      it "is successful" do
+        expect do
+          post :create, { tiebreaker: { tiebreaker: :most_points } }
+        end.to change(Tiebreaker, :count).by(1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:notice]).to eq(I18n.t(:added_tiebreaker))
+      end
+
+      it "fails correctly" do
+        create(:tiebreaker, tiebreaker: :most_points)
+
+        expect do
+          post :create, tiebreaker: { tiebreaker: :most_points }
+        end.to change{ Tiebreaker.count }.by(0)
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:index)
+        expect(flash[:alert]).to eq(I18n.t(:add_tiebreaker_failed))
+      end
+    end
+
+    describe "POST update" do
+      let(:tiebreaker1) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+      let(:tiebreaker2) { create(:tiebreaker, tiebreaker: :fewest_played, ordinal: 2) }
+
+      it "is successful" do
+        post :update, id: tiebreaker2.to_param, tiebreaker: { ordinal_position: 1 }
+
+        expect(tiebreaker1.reload.ordinal).to be > tiebreaker2.reload.ordinal
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "DELETE destroy" do
+      let!(:tiebreaker) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+
+      it "is successful" do
+        expect do
+          post :destroy, id: tiebreaker.to_param
+        end.to change(Tiebreaker, :count).by(-1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:notice]).to eq(I18n.t(:removed_tiebreaker))
+      end
+    end
+  end
+
+  context "not authorised" do
+    describe "GET index" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { get :index }
+      end
+    end
+
+    describe "POST create" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { post :create }
+      end
+    end
+
+    describe "POST update" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { post :update, id: 1 }
+      end
+    end
+
+    describe "DELETE destroy" do
+      it_behaves_like "a restricted controller" do
+        let(:go) { delete :destroy, id: 1 }
+      end
+    end
+  end
+end

--- a/spec/controllers/tiebreakers_controller_spec.rb
+++ b/spec/controllers/tiebreakers_controller_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe TiebreakersController, type: :controller do
   context "authorised" do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:authorise)
-        .and_return(nil)
+      allow_any_instance_of(ApplicationController).to receive(:authorise).
+        and_return(nil)
     end
 
     describe "GET index" do
       before do
-        create(:tiebreaker, tiebreaker: :most_points)
+        create_tiebreaker(:most_points)
         get :index
       end
 
@@ -27,7 +27,7 @@ RSpec.describe TiebreakersController, type: :controller do
     describe "POST create" do
       it "is successful" do
         expect do
-          post :create, { tiebreaker: { tiebreaker: :most_points } }
+          post :create, tiebreaker: { tiebreaker: :most_points }
         end.to change(Tiebreaker, :count).by(1)
 
         expect(response).to have_http_status(:redirect)
@@ -35,11 +35,11 @@ RSpec.describe TiebreakersController, type: :controller do
       end
 
       it "fails correctly" do
-        create(:tiebreaker, tiebreaker: :most_points)
+        create_tiebreaker(:most_points)
 
         expect do
           post :create, tiebreaker: { tiebreaker: :most_points }
-        end.to change{ Tiebreaker.count }.by(0)
+        end.to change { Tiebreaker.count }.by(0)
 
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:index)
@@ -48,11 +48,13 @@ RSpec.describe TiebreakersController, type: :controller do
     end
 
     describe "POST update" do
-      let(:tiebreaker1) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
-      let(:tiebreaker2) { create(:tiebreaker, tiebreaker: :fewest_played, ordinal: 2) }
+      let(:tiebreaker1) { create_tiebreaker(:most_points, 1) }
+      let(:tiebreaker2) { create_tiebreaker(:fewest_played, 2) }
 
       it "is successful" do
-        post :update, id: tiebreaker2.to_param, tiebreaker: { ordinal_position: 1 }
+        post :update,
+          id: tiebreaker2.to_param,
+          tiebreaker: { ordinal_position: 1 }
 
         expect(tiebreaker1.reload.ordinal).to be > tiebreaker2.reload.ordinal
         expect(response).to have_http_status(:ok)
@@ -60,7 +62,7 @@ RSpec.describe TiebreakersController, type: :controller do
     end
 
     describe "DELETE destroy" do
-      let!(:tiebreaker) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+      let!(:tiebreaker) { create_tiebreaker(:most_points, 1) }
 
       it "is successful" do
         expect do

--- a/spec/factories/tiebreakers.rb
+++ b/spec/factories/tiebreakers.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :tiebreaker do
+    tiebreaker :most_points
+    ordinal 1
+  end
+end

--- a/spec/helpers/league_helper_spec.rb
+++ b/spec/helpers/league_helper_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe LeagueHelper, type: :helper do
+  describe "#tab_class" do
+    it "returns correct class for active tab" do
+      expect(helper.tab_class(:current, :current)).to eq(:active)
+    end
+
+    it "returns correct class for inactive tab" do
+      expect(helper.tab_class(:other, :current)).to eq(nil)
+    end
+  end
+end

--- a/spec/helpers/tiebreaker_helper_spec.rb
+++ b/spec/helpers/tiebreaker_helper_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe TiebreakerHelper, type: :helper do
+  describe "#tiebreaker_options" do
+    before do
+      create(:tiebreaker, tiebreaker: :most_points)
+    end
+
+    it "returns correct options" do
+      expect(helper.tiebreaker_options).to include([t(:most_weak_side_wins), "most_weak_side_wins"])
+      expect(helper.tiebreaker_options).to include([t(:fewest_played), "fewest_played"])
+      expect(helper.tiebreaker_options).not_to include([t(:most_points), "most_points"])
+    end
+  end
+end

--- a/spec/helpers/tiebreaker_helper_spec.rb
+++ b/spec/helpers/tiebreaker_helper_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe TiebreakerHelper, type: :helper do
   describe "#tiebreaker_options" do
+    let(:options) { helper.tiebreaker_options }
     before do
       create(:tiebreaker, tiebreaker: :most_points)
     end
 
     it "returns correct options" do
-      expect(helper.tiebreaker_options).to include([t(:most_weak_side_wins), "most_weak_side_wins"])
-      expect(helper.tiebreaker_options).to include([t(:fewest_played), "fewest_played"])
-      expect(helper.tiebreaker_options).not_to include([t(:most_points), "most_points"])
+      [:most_weak_side_wins, :fewest_played].each do |o|
+        expect(options).to include([t(o), o.to_s])
+      end
+      expect(options).not_to include([t(:most_points), "most_points"])
     end
   end
 end

--- a/spec/models/ruleset_spec.rb
+++ b/spec/models/ruleset_spec.rb
@@ -24,4 +24,19 @@ RSpec.describe Ruleset, type: :model do
       end
     end
   end
+
+  describe "#rankers" do
+    let(:rankers) { ruleset.rankers }
+
+    before do
+      create(:tiebreaker, tiebreaker: :most_points, ordinal: 1)
+      create(:tiebreaker, tiebreaker: :most_weak_side_wins, ordinal: 2)
+    end
+
+    it "returns rankers in order" do
+      expect(rankers.length).to eq(2)
+      expect(rankers.first).to eq(Ranker::MostPoints)
+      expect(rankers.second).to eq(Ranker::MostWeakSideWins)
+    end
+  end
 end

--- a/spec/models/ruleset_spec.rb
+++ b/spec/models/ruleset_spec.rb
@@ -29,14 +29,16 @@ RSpec.describe Ruleset, type: :model do
     let(:rankers) { ruleset.rankers }
 
     before do
-      create(:tiebreaker, tiebreaker: :most_points, ordinal: 1)
       create(:tiebreaker, tiebreaker: :most_weak_side_wins, ordinal: 2)
+      create(:tiebreaker, tiebreaker: :most_points, ordinal: 1)
+      create(:tiebreaker, tiebreaker: :fewest_played, ordinal: 3)
     end
 
     it "returns rankers in order" do
-      expect(rankers.length).to eq(2)
+      expect(rankers.length).to eq(3)
       expect(rankers.first).to eq(Ranker::MostPoints)
       expect(rankers.second).to eq(Ranker::MostWeakSideWins)
+      expect(rankers.third).to eq(Ranker::FewestPlayed)
     end
   end
 end

--- a/spec/models/tiebreaker_spec.rb
+++ b/spec/models/tiebreaker_spec.rb
@@ -25,4 +25,15 @@ RSpec.describe Tiebreaker, type: :model do
       expect(ordered.second).to eq(second)
     end
   end
+
+  describe ".available_tiebreakers" do
+    let!(:taken) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+    let(:available) { Tiebreaker.available_tiebreakers }
+
+    it "should return correct tiebreaker options" do
+      expect(available).to include(:most_weak_side_wins)
+      expect(available).to include(:fewest_played)
+      expect(available).not_to include(:most_points)
+    end
+  end
 end

--- a/spec/models/tiebreaker_spec.rb
+++ b/spec/models/tiebreaker_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Tiebreaker, type: :model do
   end
 
   describe ".ordered" do
-    let!(:second) { create(:tiebreaker, tiebreaker: :most_weak_side_wins, ordinal: 2) }
-    let!(:first) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+    let!(:second) { create_tiebreaker(:most_weak_side_wins, 2) }
+    let!(:first) { create_tiebreaker(:most_points, 1) }
     let(:ordered) { Tiebreaker.ordered }
 
     it "should return tiebreakers in order" do
@@ -27,7 +27,7 @@ RSpec.describe Tiebreaker, type: :model do
   end
 
   describe ".available_tiebreakers" do
-    let!(:taken) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+    let!(:taken) { create_tiebreaker(:most_points, 1) }
     let(:available) { Tiebreaker.available_tiebreakers }
 
     it "should return correct tiebreaker options" do

--- a/spec/models/tiebreaker_spec.rb
+++ b/spec/models/tiebreaker_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Tiebreaker, type: :model do
+  describe "validation" do
+    let(:tiebreaker) { build(:tiebreaker, tiebreaker: :most_points) }
+
+    it "should be valid" do
+      expect(tiebreaker).to be_valid
+    end
+
+    context "invalid" do
+      it "should have unique tiebreaker" do
+        create(:tiebreaker, tiebreaker: :most_points)
+
+        expect(tiebreaker).not_to be_valid
+      end
+    end
+  end
+
+  describe ".ordered" do
+    let!(:second) { create(:tiebreaker, tiebreaker: :most_weak_side_wins, ordinal: 2) }
+    let!(:first) { create(:tiebreaker, tiebreaker: :most_points, ordinal: 1) }
+    let(:ordered) { Tiebreaker.ordered }
+
+    it "should return tiebreakers in order" do
+      expect(ordered.first).to eq(first)
+      expect(ordered.second).to eq(second)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,4 +35,5 @@ RSpec.configure do |config|
 
   config.include LeaderboardHelper
   config.include AchievementHelper
+  config.include TiebreakerHelper
 end

--- a/spec/support/tiebreaker_helper.rb
+++ b/spec/support/tiebreaker_helper.rb
@@ -1,0 +1,5 @@
+module TiebreakerHelper
+  def create_tiebreaker(tiebreaker, ordinal = 0)
+    create(:tiebreaker, tiebreaker: tiebreaker, ordinal: ordinal)
+  end
+end


### PR DESCRIPTION
User can edit the tiebreakers used in calculating league standings.
Three tiebreakers are predefined, but others can be added in the future.

Refactored edit league page into separate tabs.