### PR TITLE
Add strength of schedule tiebreaker

### DIFF
--- a/app/helpers/leaderboard_helper.rb
+++ b/app/helpers/leaderboard_helper.rb
@@ -6,4 +6,8 @@ module LeaderboardHelper
   def achievement_points_active?
     Achievement.count > 0
   end
+
+  def strength_of_schedule_active?
+    Tiebreaker.highest_strength_of_schedule.exists?
+  end
 end

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -24,9 +24,8 @@ class Leaderboard
 
   def rows
     @rows ||= @rows_by_player.map do |_, row|
-      row.tap do |row|
-        @ruleset.apply_stats(row, @rows_by_player)
-      end
+      @ruleset.apply_stats(row, @rows_by_player)
+      row
     end
   end
 

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -24,7 +24,9 @@ class Leaderboard
 
   def rows
     @rows ||= @rows_by_player.map do |_, row|
-      @ruleset.apply_stats(row)
+      row.tap do |row|
+        @ruleset.apply_stats(row, @rows_by_player)
+      end
     end
   end
 

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -1,16 +1,14 @@
 class Leaderboard
-  attr_reader :rows
-
   def initialize(games, ruleset)
     @ruleset = ruleset
-    @rows = {}
+    @rows_by_player = {}
     games.each do |game|
       process_game(game)
     end
   end
 
   def sorted_rows
-    rows.map { |_, row| row }.sort.tap do |sorted|
+    rows.sort.tap do |sorted|
       sorted.each_with_index do |row, index|
         row.position = index + 1
       end
@@ -24,6 +22,12 @@ class Leaderboard
     nil
   end
 
+  def rows
+    @rows_by_player.map do |_, row|
+      @ruleset.apply_stats(row)
+    end
+  end
+
   private
 
   def process_game(game)
@@ -32,6 +36,6 @@ class Leaderboard
   end
 
   def row(player)
-    @rows[player.id] ||= LeaderboardRow.new(player, @ruleset)
+    @rows_by_player[player.id] ||= LeaderboardRow.new(player, @ruleset)
   end
 end

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -8,7 +8,7 @@ class Leaderboard
   end
 
   def sorted_rows
-    rows.sort.tap do |sorted|
+    @sorted_rows ||= rows.sort.tap do |sorted|
       sorted.each_with_index do |row, index|
         row.position = index + 1
       end
@@ -19,11 +19,11 @@ class Leaderboard
     sorted_rows.each do |row|
       return row if row.player == player
     end
-    nil
+    Null::LeaderboardRow.new(player)
   end
 
   def rows
-    @rows_by_player.map do |_, row|
+    @rows ||= @rows_by_player.map do |_, row|
       @ruleset.apply_stats(row)
     end
   end

--- a/app/models/leaderboard_row.rb
+++ b/app/models/leaderboard_row.rb
@@ -3,7 +3,7 @@ class LeaderboardRow
 
   attr_accessor :position
   attr_reader :player, :points, :played, :corp_wins, :runner_wins
-  attr_reader :participation_points, :achievement_points
+  attr_reader :result_points, :participation_points, :achievement_points
 
   delegate :points_for_result, to: :@ruleset
   delegate :points_for_participation, to: :@ruleset
@@ -15,6 +15,7 @@ class LeaderboardRow
     @played = 0
     @corp_wins = 0
     @runner_wins = 0
+    @result_points = 0
     @participation_points = 0
     @achievement_points = 0
     @extra = {}
@@ -26,7 +27,10 @@ class LeaderboardRow
     @played += 1
     @corp_wins += 1 if corp?(game) && result(game) == :win
     @runner_wins += 1 if runner?(game) && result(game) == :win
-    @points += points_for_result(result(game))
+    points_for_result(result(game)).tap do |rp|
+      @points += rp
+      @result_points += rp
+    end
     game.points_for_achievements(@player).tap do |ap|
       @points += ap
       @achievement_points += ap

--- a/app/models/leaderboard_row.rb
+++ b/app/models/leaderboard_row.rb
@@ -17,6 +17,7 @@ class LeaderboardRow
     @runner_wins = 0
     @participation_points = 0
     @achievement_points = 0
+    @extra = {}
 
     @ruleset = ruleset
   end
@@ -42,6 +43,15 @@ class LeaderboardRow
 
   def weak_side_wins
     @corp_wins > @runner_wins ? @runner_wins : @corp_wins
+  end
+
+  def add_stat(key, value)
+    @extra[key] = value
+  end
+
+  def method_missing(name)
+    return @extra[name] if @extra.has_key?(name)
+    super
   end
 
   private

--- a/app/models/null/leaderboard_row.rb
+++ b/app/models/null/leaderboard_row.rb
@@ -1,0 +1,36 @@
+module Null
+  class LeaderboardRow
+    attr_reader :player
+
+    def initialize(player)
+      @player = player
+    end
+
+    def position
+    end
+
+    def played
+      0
+    end
+
+    def corp_wins
+      0
+    end
+
+    def runner_wins
+      0
+    end
+
+    def participation_points
+      0
+    end
+
+    def achievement_points
+      0
+    end
+
+    def points
+      0
+    end
+  end
+end

--- a/app/models/ranker/base.rb
+++ b/app/models/ranker/base.rb
@@ -1,0 +1,10 @@
+module Ranker
+  class Base
+    def self.apply_stats(row)
+    end
+
+    def self.compare(a, b)
+      0
+    end
+  end
+end

--- a/app/models/ranker/base.rb
+++ b/app/models/ranker/base.rb
@@ -1,9 +1,9 @@
 module Ranker
   class Base
-    def self.apply_stats(row)
+    def self.apply_stats(*args)
     end
 
-    def self.compare(a, b)
+    def self.compare(*args)
       0
     end
   end

--- a/app/models/ranker/base.rb
+++ b/app/models/ranker/base.rb
@@ -1,9 +1,9 @@
 module Ranker
   class Base
-    def self.apply_stats(*args)
+    def self.apply_stats(*)
     end
 
-    def self.compare(*args)
+    def self.compare(*)
       0
     end
   end

--- a/app/models/ranker/fewest_played.rb
+++ b/app/models/ranker/fewest_played.rb
@@ -1,5 +1,5 @@
 module Ranker
-  class FewestPlayed
+  class FewestPlayed < Base
     def self.compare(a, b)
       a.played <=> b.played
     end

--- a/app/models/ranker/highest_strength_of_schedule.rb
+++ b/app/models/ranker/highest_strength_of_schedule.rb
@@ -1,0 +1,16 @@
+module Ranker
+  class HighestStrengthOfSchedule < Base
+    def self.apply_stats(row, all_rows, _)
+      sos = 0
+      row.player.games.each do |game|
+        opponent = game.opponent(row.player)
+        sos += all_rows[opponent.id].result_points
+      end
+      row.add_stat(:sos, sos)
+    end
+
+    def self.compare(a, b)
+      -(a.sos <=> b.sos)
+    end
+  end
+end

--- a/app/models/ranker/most_points.rb
+++ b/app/models/ranker/most_points.rb
@@ -1,5 +1,5 @@
 module Ranker
-  class MostPoints
+  class MostPoints < Base
     def self.compare(a, b)
       -(a.points <=> b.points)
     end

--- a/app/models/ranker/most_weak_side_wins.rb
+++ b/app/models/ranker/most_weak_side_wins.rb
@@ -1,5 +1,5 @@
 module Ranker
-  class MostWeakSideWins
+  class MostWeakSideWins < Base
     def self.compare(a, b)
       -(a.weak_side_wins <=> b.weak_side_wins)
     end

--- a/app/models/ruleset.rb
+++ b/app/models/ruleset.rb
@@ -25,9 +25,7 @@ class Ruleset
     end
   end
 
-  def apply_stats(row)
-    row.tap do |row|
-      rankers.each { |ranker| ranker.apply_stats(row) }
-    end
+  def apply_stats(row, all_rows)
+    rankers.each { |ranker| ranker.apply_stats(row, all_rows, self) }
   end
 end

--- a/app/models/ruleset.rb
+++ b/app/models/ruleset.rb
@@ -24,4 +24,10 @@ class Ruleset
       "Ranker::#{t.tiebreaker.camelize}".constantize
     end
   end
+
+  def apply_stats(row)
+    row.tap do |row|
+      rankers.each { |ranker| ranker.apply_stats(row) }
+    end
+  end
 end

--- a/app/models/tiebreaker.rb
+++ b/app/models/tiebreaker.rb
@@ -1,5 +1,10 @@
 class Tiebreaker < ActiveRecord::Base
-  enum tiebreaker: [:most_points, :most_weak_side_wins, :fewest_played]
+  enum tiebreaker: [
+    :most_points,
+    :most_weak_side_wins,
+    :fewest_played,
+    :highest_strength_of_schedule
+  ]
   validates :tiebreaker, uniqueness: true
 
   include RankedModel

--- a/app/views/leaderboard/_table.html.haml
+++ b/app/views/leaderboard/_table.html.haml
@@ -6,6 +6,7 @@
     %th= t(:wins_by_side)
     %th= t(:participation_points) if participation_points_active?
     %th= t(:achievement_points) if achievement_points_active?
+    %th= t(:strength_of_schedule) if strength_of_schedule_active?
     %th= t(:leaderboard_points)
   - rows.each do |row|
     %tr
@@ -15,4 +16,5 @@
       %td= "#{row.corp_wins}/#{row.runner_wins}"
       %td= row.participation_points if participation_points_active?
       %td= row.achievement_points if achievement_points_active?
+      %td= row.sos if strength_of_schedule_active?
       %td= row.points

--- a/app/views/players/show.html.haml
+++ b/app/views/players/show.html.haml
@@ -1,5 +1,5 @@
 %h2= @player.name
-= render "leaderboard/table", rows: [@leaderboard_row] if @leaderboard_row
+= render "leaderboard/table", rows: [@leaderboard_row]
 .row
   %h3= t(:games)
   - @games.keys.sort.each do |week|

--- a/spec/controllers/players_controller_spec.rb
+++ b/spec/controllers/players_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe PlayersController, type: :controller do
           get :show, id: gameless_player.id
 
           expect(response).to have_http_status(:ok)
-          expect(assigns(:leaderboard_row)).to eq(nil)
+          expect(assigns(:leaderboard_row)).to be_a(Null::LeaderboardRow)
         end
       end
     end

--- a/spec/helpers/leaderboard_helper_spec.rb
+++ b/spec/helpers/leaderboard_helper_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe LeaderboardHelper, type: :helper do
+  describe "#participation_points_active?" do
+    context "when points are awarded for participation" do
+      before { create(:rule, key: :points_for_participation, value: 1) }
+
+      it { expect(helper.participation_points_active?).to eq(true) }
+    end
+
+    context "when points are not awarded for participation" do
+      it { expect(helper.participation_points_active?).to eq(false) }
+    end
+  end
+
+  describe "#achievement_points_active?" do
+    context "when achievements exist" do
+      before { create(:achievement) }
+
+      it { expect(helper.achievement_points_active?).to eq(true) }
+    end
+
+    context "when achievements do not exist" do
+      it { expect(helper.achievement_points_active?).to eq(false) }
+    end
+  end
+
+  describe "#strength_of_schedule_active?" do
+    context "when SOS tiebreaker exists" do
+      before { create(:tiebreaker, tiebreaker: :highest_strength_of_schedule) }
+
+      it { expect(helper.strength_of_schedule_active?).to eq(true) }
+    end
+
+    context "when SOS tiebreaker does not exist" do
+      it { expect(helper.strength_of_schedule_active?).to eq(false) }
+    end
+  end
+end

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe Leaderboard, type: :model do
 
         leaderboard.rows
       end
+
+      it "should be able to set and get custom stats" do
+        row.add_stat(:test, 99)
+
+        expect(row.test).to eq(99)
+      end
+
+      it "should correctly raise error if key doesn't exist" do
+        expect do
+          row.this_doesnt_exist
+        end.to raise_error(NoMethodError)
+      end
     end
   end
 

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -1,8 +1,5 @@
 RSpec.describe Leaderboard, type: :model do
-  let(:common_player) { create(:player) }
-  let(:game1) { create(:game, corp: common_player, result: :corp_win) }
-  let(:game2) { create(:game, runner: common_player, result: :runner_win) }
-  let(:leaderboard) { create_leaderboard(games: [game1, game2]) }
+  create_sample_leaderboard!
 
   it "should build correct leaderboard" do
     expect(leaderboard.rows.count).to be(3)
@@ -15,6 +12,10 @@ RSpec.describe Leaderboard, type: :model do
     end
 
     let(:row) { leaderboard.row_for(common_player) }
+
+    it "handles invalid player" do
+      expect(leaderboard.row_for(create(:player))).to be_a(Null::LeaderboardRow)
+    end
 
     describe("#played") { it { expect(row.played).to be(2) } }
     describe("#corp_wins") { it { expect(row.corp_wins).to be(1) } }

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Leaderboard, type: :model do
       create(:rule, key: :points_for_participation, value: 2)
     end
 
-    let(:row) { leaderboard.rows[common_player.id] }
+    let(:row) { leaderboard.row_for(common_player) }
 
     describe("#played") { it { expect(row.played).to be(2) } }
     describe("#corp_wins") { it { expect(row.corp_wins).to be(1) } }
@@ -39,6 +39,14 @@ RSpec.describe Leaderboard, type: :model do
       describe("#points") { it { expect(row.points).to eq(11) } }
       describe("#achievement_points") do
         it { expect(row.achievement_points).to eq(3) }
+      end
+    end
+
+    context "with special tiebreaker stats" do
+      it "should apply special stats to each row" do
+        expect(default_ruleset).to receive(:apply_stats).exactly(3).times
+
+        leaderboard.rows
       end
     end
   end

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Leaderboard, type: :model do
     describe("#participation_points") do
       it { expect(row.participation_points).to be(8) }
     end
+    describe("#result_points") { it { expect(row.result_points).to be(5) } }
 
     context "with achievement" do
       let(:achievement) { create(:achievement, side: :corp, points: 3) }

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -1,29 +1,24 @@
 RSpec.describe Leaderboard, type: :model do
-  create_sample_leaderboard!
+  create_sample_league
 
   it "should build correct leaderboard" do
     expect(leaderboard.rows.count).to be(3)
   end
 
   context "row" do
-    before do
-      create(:rule, key: :points_for_win, value: 2)
-      create(:rule, key: :points_for_participation, value: 2)
-    end
-
-    let(:row) { leaderboard.row_for(common_player) }
+    let(:row) { leaderboard.row_for(adam) }
 
     it "handles invalid player" do
       expect(leaderboard.row_for(create(:player))).to be_a(Null::LeaderboardRow)
     end
 
-    describe("#played") { it { expect(row.played).to be(2) } }
+    describe("#played") { it { expect(row.played).to be(8) } }
     describe("#corp_wins") { it { expect(row.corp_wins).to be(1) } }
     describe("#runner_wins") { it { expect(row.runner_wins).to be(1) } }
-    describe("#points") { it { expect(row.points).to be(8) } }
+    describe("#points") { it { expect(row.points).to be(13) } }
     describe("#weak_side_wins") { it { expect(row.weak_side_wins).to be(1) } }
     describe("#participation_points") do
-      it { expect(row.participation_points).to be(4) }
+      it { expect(row.participation_points).to be(8) }
     end
 
     context "with achievement" do
@@ -31,13 +26,13 @@ RSpec.describe Leaderboard, type: :model do
       let!(:ea) do
         create(
           :earned_achievement,
-          player: common_player,
+          player: adam,
           game: game1,
           achievement: achievement
         )
       end
 
-      describe("#points") { it { expect(row.points).to eq(11) } }
+      describe("#points") { it { expect(row.points).to eq(16) } }
       describe("#achievement_points") do
         it { expect(row.achievement_points).to eq(3) }
       end
@@ -68,7 +63,7 @@ RSpec.describe Leaderboard, type: :model do
     let(:sorted) { leaderboard.sorted_rows }
 
     it "correctly sorts rows" do
-      expect(sorted.first.player).to be(common_player)
+      expect(sorted.first.player).to be(chuck)
     end
   end
 end

--- a/spec/models/ranker/base_spec.rb
+++ b/spec/models/ranker/base_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Ranker::Base, type: :model do
 
   it "should apply no extra stats" do
     expect do
-      subject.apply_stats(row1)
+      subject.apply_stats(row1, nil, nil)
     end.not_to change { row1 }
   end
 end

--- a/spec/models/ranker/base_spec.rb
+++ b/spec/models/ranker/base_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Ranker::Base, type: :model do
+  subject { Ranker::Base }
+  let(:row1) { instance_double(LeaderboardRow) }
+  let(:row2) { instance_double(LeaderboardRow) }
+
+  it "should rank neutrally" do
+    expect(subject.compare(row1, row2)).to be(0)
+    expect(subject.compare(row1, row1)).to be(0)
+    expect(subject.compare(row2, row1)).to be(0)
+  end
+
+  it "should apply no extra stats" do
+    expect do
+      subject.apply_stats(row1)
+    end.not_to change { row1 }
+  end
+end

--- a/spec/models/ranker/highest_strength_of_schedule_spec.rb
+++ b/spec/models/ranker/highest_strength_of_schedule_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Ranker::HighestStrengthOfSchedule, type: :model do
+  subject { Ranker::HighestStrengthOfSchedule }
+  create_sample_league
+
+  before do
+    create(:tiebreaker, tiebreaker: :highest_strength_of_schedule)
+  end
+
+  it "should contain special data about strength of schedule" do
+    expect(adam_row.sos).to eq(68)
+    expect(ben_row.sos).to eq(56)
+    expect(chuck_row.sos).to eq(52)
+  end
+
+  it "should rank by sos" do
+    expect(subject.compare(adam_row, ben_row)).to be(-1)
+    expect(subject.compare(adam_row, adam_row)).to be(0)
+    expect(subject.compare(ben_row, adam_row)).to be(1)
+  end
+end

--- a/spec/models/ruleset_spec.rb
+++ b/spec/models/ruleset_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Ruleset, type: :model do
   describe "#apply_stats" do
     let(:player) { create(:player) }
     let(:row) { LeaderboardRow.new(player, ruleset) }
+    let(:all_rows) { double("Collection of Leaderboard Rows") }
 
     before do
       create(:tiebreaker, tiebreaker: :most_points)
@@ -52,10 +53,10 @@ RSpec.describe Ruleset, type: :model do
     end
 
     it "should apply complex stats for each tiebreaker" do
-      expect(Ranker::MostPoints).to receive(:apply_stats).with(row)
-      expect(Ranker::FewestPlayed).to receive(:apply_stats).with(row)
+      expect(Ranker::MostPoints).to receive(:apply_stats).with(row, all_rows, ruleset)
+      expect(Ranker::FewestPlayed).to receive(:apply_stats).with(row, all_rows, ruleset)
 
-      ruleset.apply_stats(row)
+      ruleset.apply_stats(row, all_rows)
     end
   end
 end

--- a/spec/models/ruleset_spec.rb
+++ b/spec/models/ruleset_spec.rb
@@ -41,4 +41,21 @@ RSpec.describe Ruleset, type: :model do
       expect(rankers.third).to eq(Ranker::FewestPlayed)
     end
   end
+
+  describe "#apply_stats" do
+    let(:player) { create(:player) }
+    let(:row) { LeaderboardRow.new(player, ruleset) }
+
+    before do
+      create(:tiebreaker, tiebreaker: :most_points)
+      create(:tiebreaker, tiebreaker: :fewest_played)
+    end
+
+    it "should apply complex stats for each tiebreaker" do
+      expect(Ranker::MostPoints).to receive(:apply_stats).with(row)
+      expect(Ranker::FewestPlayed).to receive(:apply_stats).with(row)
+
+      ruleset.apply_stats(row)
+    end
+  end
 end

--- a/spec/models/ruleset_spec.rb
+++ b/spec/models/ruleset_spec.rb
@@ -53,8 +53,10 @@ RSpec.describe Ruleset, type: :model do
     end
 
     it "should apply complex stats for each tiebreaker" do
-      expect(Ranker::MostPoints).to receive(:apply_stats).with(row, all_rows, ruleset)
-      expect(Ranker::FewestPlayed).to receive(:apply_stats).with(row, all_rows, ruleset)
+      expect(Ranker::MostPoints).to receive(:apply_stats).
+        with(row, all_rows, ruleset)
+      expect(Ranker::FewestPlayed).to receive(:apply_stats).
+        with(row, all_rows, ruleset)
 
       ruleset.apply_stats(row, all_rows)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.include LeaderboardHelper
+  config.include Spec::LeaderboardHelper
   config.include AchievementHelper
   config.include TiebreakerHelper
   config.include GameHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,4 +36,5 @@ RSpec.configure do |config|
   config.include LeaderboardHelper
   config.include AchievementHelper
   config.include TiebreakerHelper
+  config.include GameHelper
 end

--- a/spec/support/game_helper.rb
+++ b/spec/support/game_helper.rb
@@ -1,0 +1,5 @@
+module GameHelper
+  def create_game(corp, runner, result)
+    create(:game, corp: corp, runner: runner, result: result)
+  end
+end

--- a/spec/support/leaderboard_helper.rb
+++ b/spec/support/leaderboard_helper.rb
@@ -11,3 +11,10 @@ module LeaderboardHelper
     @ruleset ||= Ruleset.new
   end
 end
+
+def create_sample_leaderboard!
+  let(:common_player) { create(:player) }
+  let(:game1) { create(:game, corp: common_player, result: :corp_win) }
+  let(:game2) { create(:game, runner: common_player, result: :runner_win) }
+  let(:leaderboard) { create_leaderboard(games: [game1, game2]) }
+end

--- a/spec/support/leaderboard_helper.rb
+++ b/spec/support/leaderboard_helper.rb
@@ -11,10 +11,3 @@ module LeaderboardHelper
     @ruleset ||= Ruleset.new
   end
 end
-
-def create_sample_leaderboard!
-  let(:common_player) { create(:player) }
-  let(:game1) { create(:game, corp: common_player, result: :corp_win) }
-  let(:game2) { create(:game, runner: common_player, result: :runner_win) }
-  let(:leaderboard) { create_leaderboard(games: [game1, game2]) }
-end

--- a/spec/support/leaderboard_helper.rb
+++ b/spec/support/leaderboard_helper.rb
@@ -8,6 +8,6 @@ module LeaderboardHelper
   end
 
   def default_ruleset
-    Ruleset.new
+    @ruleset ||= Ruleset.new
   end
 end

--- a/spec/support/leaderboard_helper.rb
+++ b/spec/support/leaderboard_helper.rb
@@ -1,13 +1,15 @@
-module LeaderboardHelper
-  def create_leaderboard(games: default_games, ruleset: default_ruleset)
-    Leaderboard.new(games, ruleset)
-  end
+module Spec
+  module LeaderboardHelper
+    def create_leaderboard(games: default_games, ruleset: default_ruleset)
+      Leaderboard.new(games, ruleset)
+    end
 
-  def default_games
-    [create(:game), create(:game)]
-  end
+    def default_games
+      [create(:game), create(:game)]
+    end
 
-  def default_ruleset
-    @ruleset ||= Ruleset.new
+    def default_ruleset
+      @ruleset ||= Ruleset.new
+    end
   end
 end

--- a/spec/support/sample_league.rb
+++ b/spec/support/sample_league.rb
@@ -1,0 +1,49 @@
+def create_sample_league
+  before do
+    create(:rule, key: :points_for_win, value: 2)
+    create(:rule, key: :points_for_time_win, value: 1)
+    create(:rule, key: :points_for_tie, value: 1)
+    create(:rule, key: :points_for_loss, value: 0)
+    create(:rule, key: :points_for_participation, value: 1)
+    create(:tiebreaker, tiebreaker: :most_points)
+  end
+
+  let(:adam) { create(:player, name: "Adam") }
+  let(:ben) { create(:player, name: "Ben") }
+  let(:chuck) { create(:player, name: "Chuck") }
+
+  let(:game1) { create(:game, corp: adam, runner: ben, result: :corp_win) }
+  let(:game2) { create(:game, corp: ben, runner: adam, result: :corp_win) }
+  let(:game3) { create(:game, corp: adam, runner: chuck, result: :runner_win) }
+  let(:game4) { create(:game, corp: chuck, runner: adam, result: :corp_win) }
+  let(:game5) { create(:game, corp: ben, runner: chuck, result: :corp_time_win) }
+  let(:game6) { create(:game, corp: chuck, runner: ben, result: :corp_win) }
+  let(:game7) { create(:game, corp: adam, runner: ben, result: :runner_win) }
+  let(:game8) { create(:game, corp: ben, runner: adam, result: :corp_win) }
+  let(:game9) { create(:game, corp: adam, runner: chuck, result: :tie) }
+  let(:game10) { create(:game, corp: chuck, runner: adam, result: :runner_win) }
+  let(:game11) { create(:game, corp: ben, runner: chuck, result: :corp_time_win) }
+  let(:game12) { create(:game, corp: chuck, runner: ben, result: :corp_win) }
+
+  # Breakdown
+  # Adam: 2 wins, 5 losses, 1 tie
+  # Ben: 3 wins, 2 time wins, 3 losses
+  # Chuck: 4 wins, 3 losses, 1 tie
+
+  let(:games) do
+    [
+      game1, game2, game3, game4, game5, game6,
+      game7, game8, game9, game10, game11, game12
+    ]
+  end
+
+  let(:leaderboard) { create_leaderboard(games: games) }
+end
+
+def create_sample_league!
+  create_sample_league
+
+  before do
+    leaderboard
+  end
+end

--- a/spec/support/sample_league.rb
+++ b/spec/support/sample_league.rb
@@ -12,18 +12,18 @@ def create_sample_league
   let(:ben) { create(:player, name: "Ben") }
   let(:chuck) { create(:player, name: "Chuck") }
 
-  let(:game1) { create(:game, corp: adam, runner: ben, result: :corp_win) }
-  let(:game2) { create(:game, corp: ben, runner: adam, result: :corp_win) }
-  let(:game3) { create(:game, corp: adam, runner: chuck, result: :runner_win) }
-  let(:game4) { create(:game, corp: chuck, runner: adam, result: :corp_win) }
-  let(:game5) { create(:game, corp: ben, runner: chuck, result: :corp_time_win) }
-  let(:game6) { create(:game, corp: chuck, runner: ben, result: :corp_win) }
-  let(:game7) { create(:game, corp: adam, runner: ben, result: :runner_win) }
-  let(:game8) { create(:game, corp: ben, runner: adam, result: :corp_win) }
-  let(:game9) { create(:game, corp: adam, runner: chuck, result: :tie) }
-  let(:game10) { create(:game, corp: chuck, runner: adam, result: :runner_win) }
-  let(:game11) { create(:game, corp: ben, runner: chuck, result: :corp_time_win) }
-  let(:game12) { create(:game, corp: chuck, runner: ben, result: :corp_win) }
+  let(:game1) { create_game(adam, ben, :corp_win) }
+  let(:game2) { create_game(ben, adam, :corp_win) }
+  let(:game3) { create_game(adam, chuck, :runner_win) }
+  let(:game4) { create_game(chuck, adam, :corp_win) }
+  let(:game5) { create_game(ben, chuck, :corp_time_win) }
+  let(:game6) { create_game(chuck, ben, :corp_win) }
+  let(:game7) { create_game(adam, ben, :runner_win) }
+  let(:game8) { create_game(ben, adam, :corp_win) }
+  let(:game9) { create_game(adam, chuck, :tie) }
+  let(:game10) { create_game(chuck, adam, :runner_win) }
+  let(:game11) { create_game(ben, chuck, :corp_time_win) }
+  let(:game12) { create_game(chuck, ben, :corp_win) }
 
   # Breakdown
   # Adam: 2 wins, 5 losses, 1 tie (5 points)

--- a/spec/support/sample_league.rb
+++ b/spec/support/sample_league.rb
@@ -26,9 +26,9 @@ def create_sample_league
   let(:game12) { create(:game, corp: chuck, runner: ben, result: :corp_win) }
 
   # Breakdown
-  # Adam: 2 wins, 5 losses, 1 tie
-  # Ben: 3 wins, 2 time wins, 3 losses
-  # Chuck: 4 wins, 3 losses, 1 tie
+  # Adam: 2 wins, 5 losses, 1 tie (5 points)
+  # Ben: 3 wins, 2 time wins, 3 losses (8 points)
+  # Chuck: 4 wins, 3 losses, 1 tie (9 points)
 
   let(:games) do
     [
@@ -38,6 +38,10 @@ def create_sample_league
   end
 
   let(:leaderboard) { create_leaderboard(games: games) }
+
+  let(:adam_row) { leaderboard.row_for(adam) }
+  let(:ben_row) { leaderboard.row_for(ben) }
+  let(:chuck_row) { leaderboard.row_for(chuck) }
 end
 
 def create_sample_league!


### PR DESCRIPTION
Includes major changes to tiebreaker to allow a ranker to gather their own metadata prior to comparisons.

Also added `Null::LeaderboardRow` and sample league data to be reused across many specs