### PR TITLE
Allow custom ranker data to be set dynamically

### DIFF
--- a/app/models/leaderboard_row.rb
+++ b/app/models/leaderboard_row.rb
@@ -53,8 +53,10 @@ class LeaderboardRow
     @extra[key] = value
   end
 
-  def method_missing(name)
-    return @extra[name] if @extra.has_key?(name)
+  def method_missing(name, value = nil, *)
+    return @extra[name.to_sym] if @extra.has_key?(name.to_sym)
+    return @extra[name[0...-1].to_sym] = value if /=$/ =~ name
+
     super
   end
 

--- a/app/models/leaderboard_row.rb
+++ b/app/models/leaderboard_row.rb
@@ -49,10 +49,6 @@ class LeaderboardRow
     @corp_wins > @runner_wins ? @runner_wins : @corp_wins
   end
 
-  def add_stat(key, value)
-    @extra[key] = value
-  end
-
   def method_missing(name, value = nil, *)
     return @extra[name.to_sym] if @extra.has_key?(name.to_sym)
     return @extra[name[0...-1].to_sym] = value if /=$/ =~ name

--- a/app/models/ranker/highest_strength_of_schedule.rb
+++ b/app/models/ranker/highest_strength_of_schedule.rb
@@ -6,7 +6,7 @@ module Ranker
         opponent = game.opponent(row.player)
         sos += all_rows[opponent.id].result_points
       end
-      row.add_stat(:sos, sos)
+      row.sos = sos
     end
 
     def self.compare(a, b)

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Leaderboard, type: :model do
       end
 
       it "should be able to set and get custom stats" do
-        row.add_stat(:test, 99)
+        row.test = 99
 
         expect(row.test).to eq(99)
       end


### PR DESCRIPTION
Suggested by @richdouglasevans
Catch calls to undefined methods of kind `my_custom_param=` to set
`my_custom_param` in custom ranker data hash