### PR TITLE
Add highlight to `success` panels in classic theme

### DIFF
--- a/app/assets/stylesheets/themes/classic.sass
+++ b/app/assets/stylesheets/themes/classic.sass
@@ -47,3 +47,6 @@ body.classic
 
   .table-striped > tbody > tr:nth-of-type(odd)
     @include dark-highlight
+
+  .panel-success .panel-heading
+    background-color: #464


### PR DESCRIPTION
This includes games that are wins in the context of a specific player and gained achievements in the context of a specific player.
![image](https://cloud.githubusercontent.com/assets/242952/10079108/26169cd4-62e0-11e5-9b0b-b5d164007847.png)

