### PR TITLE
Add game data to leaderboard rows

### DIFF
--- a/app/models/leaderboard_row.rb
+++ b/app/models/leaderboard_row.rb
@@ -4,6 +4,7 @@ class LeaderboardRow
   attr_accessor :position
   attr_reader :player, :points, :played, :corp_wins, :runner_wins, :byes
   attr_reader :result_points, :participation_points, :achievement_points
+  attr_reader :games
 
   delegate :points_for_result, to: :@ruleset
   delegate :points_for_participation, to: :@ruleset
@@ -20,6 +21,7 @@ class LeaderboardRow
     @achievement_points = 0
     @byes = 0
     @extra = {}
+    @games = []
 
     @ruleset = ruleset
   end
@@ -41,6 +43,7 @@ class LeaderboardRow
       @points += pp
       @participation_points += pp
     end
+    @games << game
   end
 
   def <=>(other)

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Leaderboard, type: :model do
     end
     describe("#result_points") { it { expect(row.result_points).to be(5) } }
     describe("#byes") { it { expect(row.byes).to be(0) } }
+    describe("#games") do
+      it { expect(row.games.count).to be(8) }
+      it { expect(row.games).to include(game1) }
+      it { expect(row.games).not_to include(game5) }
+    end
 
     context "with achievement" do
       let(:achievement) { create(:achievement, side: :corp, points: 3) }


### PR DESCRIPTION
This will allow more complex calculations to be made based on the specific games, e.g. capping participation per week