### PR TITLE
Allow league admin to keep freeform notes on players

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -42,7 +42,7 @@ class PlayersController < ApplicationController
   private
 
   def player_params
-    params.require(:player).permit(:name)
+    params.require(:player).permit(:name, :notes)
   end
 
   def find_player

--- a/app/views/players/_form.html.haml
+++ b/app/views/players/_form.html.haml
@@ -5,6 +5,10 @@
       .col-sm-10
         = f.text_field :name, class: "form-control"
     .form-group
+      = f.label :notes, t(:player_notes), class: ["col-sm-2", "control-label"]
+      .col-sm-10
+        = f.text_area :notes, class: "form-control"
+    .form-group
       .col-sm-offset-2.col-sm-10
         = button_tag class: ["btn", "btn-success"] do
           %span.glyphicon.glyphicon-pencil

--- a/app/views/players/index.html.haml
+++ b/app/views/players/index.html.haml
@@ -10,11 +10,13 @@
     %tr
       %th #
       %th= t(:player_name)
+      %th= t(:player_notes)
       %th
     - @players.each do |player|
       %tr
         %td= player.id
         %td= player.name
+        %td= player.notes
         %td
           = link_to edit_player_path(player), class: ["btn", "btn-default"] do
             %span.glyphicon.glyphicon-pencil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
   players: "Players"
   manage_players: "Manage players"
   player_name: "Name"
+  player_notes: "Notes"
   add_player: "Add player"
   created_player: "Created player"
   create_player_failed: "Couldn't create player"

--- a/db/migrate/20151020145600_add_notes_to_players.rb
+++ b/db/migrate/20151020145600_add_notes_to_players.rb
@@ -1,0 +1,5 @@
+class AddNotesToPlayers < ActiveRecord::Migration
+  def change
+    add_column :players, :notes, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150901133938) do
+ActiveRecord::Schema.define(version: 20151020145600) do
 
   create_table "achievements", force: :cascade do |t|
     t.string   "title"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20150901133938) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "notes"
   end
 
   create_table "rules", force: :cascade do |t|

--- a/spec/controllers/players_controller_spec.rb
+++ b/spec/controllers/players_controller_spec.rb
@@ -114,9 +114,12 @@ RSpec.describe PlayersController, type: :controller do
 
       it "updates player" do
         expect_any_instance_of(Player).to receive(:update_attributes)
-          .with("name" => "New name")
+          .with("name" => "New name", "notes" => "New notes")
 
-        post :update, id: player.id, player: { name: "New name" }
+        post :update, id: player.id, player: {
+          name: "New name",
+          notes: "New notes"
+        }
       end
 
       it "fails correctly" do

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :player do
     name "A Player"
+    notes "These are some notes"
   end
 end

--- a/spec/views/players/edit_spec.rb
+++ b/spec/views/players/edit_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "players/edit.html.haml", type: :view do
   before do
-    assign(:player, create(:player, name: "Player Name"))
+    assign(:player, create(:player, name: "Player Name", notes: "Player notes"))
   end
 
   it "should display player form" do
@@ -8,5 +8,6 @@ RSpec.describe "players/edit.html.haml", type: :view do
 
     expect(rendered).to have_content(t(:edit_player))
     expect(rendered).to have_field("player[name]", with: "Player Name")
+    expect(rendered).to have_field("player[notes]", with: "Player notes")
   end
 end

--- a/spec/views/players/index_spec.rb
+++ b/spec/views/players/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "players/index.html.haml", type: :view do
   before do
-    3.times { create(:player, name: "Player Name") }
+    3.times { create(:player, name: "Player Name", notes: "Player notes") }
     assign(:players, Player.all)
 
     render
@@ -10,5 +10,6 @@ RSpec.describe "players/index.html.haml", type: :view do
     expect(rendered).to have_content(t(:players))
     expect(rendered).to have_css("tr", count: 4)
     expect(rendered).to have_content("Player Name", count: 3)
+    expect(rendered).to have_content("Player notes", count: 3)
   end
 end


### PR DESCRIPTION
This will allow the admin to track useful info associated with players, such as description, availability or progress towards longer-term achievements.