### PR TITLE
Add default order to players

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -13,6 +13,8 @@ class Player < ActiveRecord::Base
   has_many :earned_achievements, dependent: :destroy
   has_many :achievements, through: :earned_achievements
 
+  default_scope { order("name ASC") }
+
   def games
     Game.where("corp_id = ? OR runner_id = ?", id, id)
   end

--- a/app/views/games/new.html.haml
+++ b/app/views/games/new.html.haml
@@ -6,13 +6,13 @@
         .panel-heading= t(:add_game_reverse_instruction)
         .panel-body
           .form-group
-            = f.label :corp_id, t(:game_corp_player), class: ["col-sm-2", "control-label"]
-            .col-sm-10
-              %p.form-control-static.game_runner_name= t(:runner)
-          .form-group
             = f.label :corp_id, t(:game_runner_player), class: ["col-sm-2", "control-label"]
             .col-sm-10
               %p.form-control-static.game_corp_name= t(:corp)
+          .form-group
+            = f.label :corp_id, t(:game_corp_player), class: ["col-sm-2", "control-label"]
+            .col-sm-10
+              %p.form-control-static.game_runner_name= t(:runner)
           .form-group
             = f.label :result, t(:game_result), class: ["col-sm-2", "control-label"]
             .col-sm-10
@@ -22,15 +22,15 @@
         .panel-body
           .col-sm-6
             %h4
-              %span.game_runner_name
-              = "(#{t(:corp)})"
-            .corp_achievements
-            - corp_achievements.each do |ach|
-              = render "achievement_field", ach: ach, game: @game, key: :reverse_achievements
-          .col-sm-6
-            %h4
               %span.game_corp_name
               = "(#{t(:runner)})"
             .runner_achievements
             - runner_achievements.each do |ach|
+              = render "achievement_field", ach: ach, game: @game, key: :reverse_achievements
+          .col-sm-6
+            %h4
+              %span.game_runner_name
+              = "(#{t(:corp)})"
+            .corp_achievements
+            - corp_achievements.each do |ach|
               = render "achievement_field", ach: ach, game: @game, key: :reverse_achievements

--- a/app/views/players/index.html.haml
+++ b/app/views/players/index.html.haml
@@ -11,13 +11,11 @@
   .col-xs-12
     %table.table
       %tr
-        %th #
         %th= t(:player_name)
         %th= t(:player_notes)
         %th
       - @players.each do |player|
         %tr
-          %td= player.id
           %td= player.name
           %td= player.notes
           %td

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -98,4 +98,17 @@ RSpec.describe Player, type: :model do
       expect(player.earned?(unearned)).to eq(false)
     end
   end
+
+  describe "order" do
+    let!(:alan) { create(:player, name: "Alan") }
+    let!(:zuzanna) { create(:player, name: "Zuzanna") }
+    let!(:brian) { create(:player, name: "Brian") }
+    let(:all) { Player.all }
+
+    it "defaults order to alphabetical by name" do
+      expect(all.first).to eq(alan)
+      expect(all.second).to eq(brian)
+      expect(all.last).to eq(zuzanna)
+    end
+  end
 end


### PR DESCRIPTION
Players will be listed in alphabetical order by name in admin screens
Also swapped the create game reverse result for for ease of use and cleaned up the player index.