### PR TITLE
Redirect to achievement management page after deleting achievement

### DIFF
--- a/app/controllers/achievements_controller.rb
+++ b/app/controllers/achievements_controller.rb
@@ -38,7 +38,7 @@ class AchievementsController < ApplicationController
 
   def destroy
     @achievement = find_achievement
-    redirect_to achievements_path,
+    redirect_to manage_achievements_path,
       notice: @achievement.destroy ? t(:deleted_achievement) : t(:delete_achievement_failed)
   end
 

--- a/spec/controllers/achievements_controller_spec.rb
+++ b/spec/controllers/achievements_controller_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe AchievementsController, type: :controller do
         delete :destroy, id: achievement_to_delete.id
 
         expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(manage_achievements_path)
         expect(flash[:notice]).to eq(I18n.t(:deleted_achievement))
       end
     end


### PR DESCRIPTION
'cos you clicked the "Delete (Achievement)" button from the "Manage Achievement" page so after deletion you should end up back there.

Previously after deleting an acheev you ended up in the "View Achievements" page and had to navigate back to the "Manage Achievement" page to continue managing acheevs.