### PR TITLE
Minor styling and workflow around achievement management

### DIFF
--- a/app/views/achievements/_form.html.haml
+++ b/app/views/achievements/_form.html.haml
@@ -10,17 +10,17 @@
         = f.text_area :description, class: "form-control"
     .form-group
       = f.label :points, t(:achievement_points), class: ["col-sm-2", "control-label"]
-      .col-sm-10
-        = f.text_field :points, class: "form-control"
+      .col-sm-2
+        = f.text_field :points, class: "form-control", type: "number", min: 1, max: 3, size: 5
     .form-group
       = f.label :side, t(:achievement_side), class: ["col-sm-2", "control-label"]
-      .col-sm-10
+      .col-sm-2
         = f.select :side, side_options, {}, class: "form-control"
     .form-group
       .col-sm-offset-2.col-sm-10
-        = button_tag class: ["btn", "btn-success"] do
-          %span.glyphicon.glyphicon-pencil
-          = t(:save_achievement)
-        %a.btn.btn-danger{ href: achievements_path }
+        %a.btn{ href: manage_achievements_path }
           %span.glyphicon.glyphicon-remove
           = t(:cancel)
+        = button_tag class: ["btn", "btn-primary"] do
+          %span.glyphicon.glyphicon-pencil
+          = t(:save_achievement)

--- a/app/views/achievements/manage.html.haml
+++ b/app/views/achievements/manage.html.haml
@@ -1,18 +1,18 @@
 .row
   .col-xs-12.table-topper
     %h2= t(:achievements)
-    = link_to new_achievement_path, class: ["btn", "btn-success"] do
-      %span.glyphicon.glyphicon-plus
-      = t(:add_achievement)
 .row
   .col-xs-12
-    %table.table.achievements
+    %table.table.achievements.table-condensed
       %tr
         %th #
         %th= t(:achievement_title)
         %th= t(:achievement_side)
         %th= t(:achievement_points)
         %th
+          = link_to new_achievement_path, class: ["btn", "btn-success"] do
+            %span.glyphicon.glyphicon-plus
+            = t(:add_achievement)
       - @achievements.each do |achievement|
         %tr
           %td= achievement.id
@@ -20,9 +20,10 @@
           %td= t(achievement.side)
           %td= achievement.points
           %td
-            = link_to edit_achievement_path(achievement), class: ["btn", "btn-default"] do
+            = link_to edit_achievement_path(achievement), class: ["btn", "btn-primary"] do
               %span.glyphicon.glyphicon-pencil
               = t(:edit_achievement)
-            = link_to achievement_path(achievement), method: :delete, class: ["btn", "btn-danger"], data: { confirm: t(:confirm_delete_achievement, title: achievement.title) } do
+            = link_to achievement_path(achievement), method: :delete, class: ["btn"],
+                      data: { confirm: t(:confirm_delete_achievement, title: achievement.title) } do
               %span.glyphicon.glyphicon-trash
               = t(:delete_achievement)


### PR DESCRIPTION
* collapse buttons making them look neater
* use primary and default styles instead of success and danger. (It's not dangerous to cancel.)
* type the achievement points form control: now typed as a "number" and configured with a sensible range of minimum and maximum values.

Redirect to achievement management page after cancelling edit achievement: 'cos you clicked the "Edit (Achievement)" button from the "Manage Achievement" page so after cancelling the edit you should end up back there.