### PR TITLE
Display side & points on acheev's title bar

### DIFF
--- a/app/assets/stylesheets/achievements.sass
+++ b/app/assets/stylesheets/achievements.sass
@@ -1,3 +1,11 @@
 .achievement_grid
-  .achievement:nth-child(4n+1)
+  .achievement:nth-child(3n+1)
     clear: left
+  .side
+    font-weight: bold
+    padding-right: 10px
+    text-transform: uppercase
+  .points
+    font-weight: bold
+    padding-left: 10px
+    border-left: 1px solid whitesmoke

--- a/app/views/achievements/_grid.html.haml
+++ b/app/views/achievements/_grid.html.haml
@@ -4,10 +4,10 @@
     .col-md-4.achievement
       .panel.panel-default{class: achievement_class(achievement, player)}
         .panel-heading
-          =achievement.title
+          = achievement.title
           .points.pull-right{title: t("achievement_points")}
-            =achievement.points
+            = achievement.points
           .side.pull-right
-            =t(achievement.side)
+            = t(achievement.side)
         .panel-body
-          =achievement.description
+          = achievement.description

--- a/app/views/achievements/_grid.html.haml
+++ b/app/views/achievements/_grid.html.haml
@@ -1,11 +1,13 @@
 - player ||= nil
 .row.achievement_grid
   - achievements.each do |achievement|
-    .col-md-3.achievement
+    .col-md-4.achievement
       .panel.panel-default{class: achievement_class(achievement, player)}
-        .panel-heading=achievement.title
+        .panel-heading
+          =achievement.title
+          .points.pull-right{title: t("achievement_points")}
+            =achievement.points
+          .side.pull-right
+            =t(achievement.side)
         .panel-body
-          =t(achievement.side)
-          ="(#{pluralize(achievement.points, t(:point))})"
-          %br
           =achievement.description

--- a/app/views/achievements/_grid.html.haml
+++ b/app/views/achievements/_grid.html.haml
@@ -5,7 +5,7 @@
       .panel.panel-default{class: achievement_class(achievement, player)}
         .panel-heading
           = achievement.title
-          .points.pull-right{title: t("achievement_points")}
+          .points.pull-right{title: t(:achievement_points)}
             = achievement.points
           .side.pull-right
             = t(achievement.side)

--- a/app/views/achievements/index.html.haml
+++ b/app/views/achievements/index.html.haml
@@ -1,4 +1,4 @@
 .row
-  .col-md-12
+  .col-xs-12
     %h2= t(:achievements)
     = render "achievements/grid", achievements: @achievements

--- a/app/views/achievements/index.html.haml
+++ b/app/views/achievements/index.html.haml
@@ -1,4 +1,4 @@
 .row
-  .col-xs-12
+  .col-md-12
     %h2= t(:achievements)
     = render "achievements/grid", achievements: @achievements

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,6 @@ en:
   manage_achievements: "Manage achievements"
   achievement_title: "Title"
   achievement_description: "Description"
-  achievement_points: "Points"
   achievement_side: "Side"
   add_achievement: "Add achievement"
   created_achievement: "Created achievement(s)"


### PR DESCRIPTION
There is lots of whitespace on the title bar; pulling this information up onto the bar fills that whitespace and leaves the description area free to display just the description of the acheev.

Someone with some UI design chops could further refine the title banner into something cooler and polished.

![Shot](http://i.imgur.com/6xOLFj1.png?1)